### PR TITLE
Fix that provider tests don't use match rules 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,11 +15,23 @@
   </properties>
 
   <dependencies>
-    <!-- https://mvnrepository.com/artifact/com.reagroup/pact-jvm-provider-spring-mvc -->
     <dependency>
-      <groupId>com.reagroup</groupId>
-      <artifactId>pact-jvm-provider-spring-mvc_2.10</artifactId>
-      <version>0.3.0</version>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <version>4.3.5.RELEASE</version>
+    </dependency>
+
+    <dependency>
+      <groupId>au.com.dius</groupId>
+      <artifactId>pact-jvm-provider-spring_2.11</artifactId>
+      <version>3.5.10</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.8.5</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/kata/pact/provider/ReviewController.java
+++ b/src/main/java/kata/pact/provider/ReviewController.java
@@ -7,8 +7,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-
 @Controller
 public class ReviewController {
     private ReviewService reviewService;
@@ -19,7 +17,7 @@ public class ReviewController {
         // assertEquals("123", id);
         // assertEquals("ben", name);
 
-        return new ReviewService().getRatings(id, name);
+        return reviewService.getRatings(id, name);
     }
 
     public ReviewController withResponseService(ReviewService reviewService) {


### PR DESCRIPTION
Replace pact-jvm-provider-spring-mvc with pact-jvm-provider-spring

References：
![https://github.com/DiUS/pact-jvm/tree/master/pact-jvm-provider-spring]()
![https://github.com/DiUS/pact-jvm/tree/master/pact-jvm-provider-junit]()
